### PR TITLE
Tests parts fiscales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 13.1.0 [#43](https://github.com/openfisca/openfisca-nouvelle_caledonie/pull/43)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/situation_de_famille.py`.
+* Détails :
+  - Ajout de la nouvelle variable ancien_combattant avec sa configuration de paramètres associée.
+  - Modification de la formule de calcul des éléments fiscaux afin de tenir compte de conditions telles que l'invalidité et le statut d'ancien combattant.
+  - Extension de la couverture des tests avec de nombreux scénarios YAML et correction de fautes de frappe mineures.
+
 ### 13.0.2 [#40](https://github.com/openfisca/openfisca-nouvelle_caledonie/pull/40)
 * Amélioration technique.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Détails :
   - Ajout de la nouvelle variable ancien_combattant avec sa configuration de paramètres associée.
   - Modification de la formule de calcul des éléments fiscaux afin de tenir compte de conditions telles que l'invalidité et le statut d'ancien combattant.
+  - Ajout du plafonnement du quotient familial intervenu en 2016.
   - Extension de la couverture des tests avec de nombreux scénarios YAML et correction de fautes de frappe mineures.
 
 ### 13.0.2 [#40](https://github.com/openfisca/openfisca-nouvelle_caledonie/pull/40)

--- a/openfisca_nouvelle_caledonie/entities.py
+++ b/openfisca_nouvelle_caledonie/entities.py
@@ -96,7 +96,7 @@ FoyerFiscal = build_entity(
         {
             "key": "enfant_accueilli",
             "plural": "enfants_accueillis",
-            "label": "Enfnts accueillis",
+            "label": "Enfants accueillis",
         },
     ],
 )

--- a/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/ancien_combattant.yaml
+++ b/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/ancien_combattant.yaml
@@ -1,0 +1,12 @@
+description: nombre de parts fiscales additionelles pour un ancien combattant ou veuf ancien combattant
+values:
+  2024-01-01:
+    value: 0.5
+metadata:
+  short_label: Parts fiscales pour une personne remplissant les conditions d'ancien combattant
+  label_en: Tax parts for a person meeting the conditions of a former combatant
+  unit: part_fiscale
+  comment: |
+    Nombre de parts fiscales pour une personne remplissant les conditions d'ancien combattant.
+    Conditions: être âgé de + de 70 ans et titulaire de la carte du combattant ou
+    veuf/veuve agé.e de + de 70 ans dont le conjoint remplissait les conditions.

--- a/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/ancien_combattant.yaml
+++ b/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/ancien_combattant.yaml
@@ -1,4 +1,4 @@
-description: nombre de parts fiscales additionelles pour un ancien combattant ou veuf ancien combattant
+description: nombre de parts fiscales additionnelles pour un ancien combattant ou veuf ancien combattant
 values:
   2024-01-01:
     value: 0.5

--- a/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/handicape.yaml
+++ b/openfisca_nouvelle_caledonie/parameters/prelevements_obligatoires/impot_revenu/parts_fiscales/handicape.yaml
@@ -1,0 +1,14 @@
+description: nombre de parts fiscales additionelles pour un déclarant handicapé
+values:
+  2024-01-01:
+    value: 0.5
+metadata:
+  short_label: Parts fiscales pour un déclarant (principal ou conjoint) handicapé
+  label_en: Tax parts for a disabled declarant (main or spouse)
+  unit: part_fiscale
+  comment: |
+    Nombre de parts fiscales pour un déclarant (principal ou conjoint) handicapé.
+    Conditions: titulaire d'une pension (militaire ou accident de travail) pour
+    invalidité d'au moins 40%, carte d'invalidité supérieure à 50% ou perte d'autonomie
+    GIR1, GIR2, GIR3 ou GIR4.
+    Veuve/veuf et conjoint avait une pension militaire pour une invalidité d'au moins 40%.

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/impot/tspr/salarie.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/impot/tspr/salarie.yaml
@@ -126,4 +126,4 @@
     revenus_categoriels_tspr: 14_600_000
     revenu_brut_global: 14_600_000
     revenu_net_global_imposable: 14_600_000
-    #impot_net: 3_042_000
+    impot_net: 3_042_000

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/impot/tspr/salarie.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/impot/tspr/salarie.yaml
@@ -33,3 +33,97 @@
     revenus_categoriels_tspr: 10_000_000 - 800_000 - 1_800_000
     parts_fiscales: 2
     impot_net: 662_000
+
+- name: Salarié marié avec 1 enfant 10_000_000
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      declarants:
+      - individu_0
+      - individu_1
+      enfants_a_charge:
+      - enfant_0
+    persons:
+      individu_0:
+        salaire_imposable: 10_000_000
+        statut_marital: marie
+      individu_1:
+        salaire_imposable: 0
+        statut_marital: marie
+      enfant_0:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2.5
+    impot_net: 383_000
+
+
+- name: Salarié marié avec 1 enfant accueilli 10_000_000
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      declarants:
+      - individu_0
+      - individu_1
+      enfants_accueillis:
+      - enfant_0
+    persons:
+      individu_0:
+        salaire_imposable: 10_000_000
+        statut_marital: marie
+      individu_1:
+        salaire_imposable: 0
+        statut_marital: marie
+      enfant_0:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2
+    impot_net: 560_500
+
+- name: Salarié marié avec 2 revenus 10_000_000 et 5_000_000
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      declarants:
+      - individu_0
+      - individu_1
+    persons:
+      individu_0:
+        salaire_imposable: 10_000_000
+        statut_marital: marie
+      individu_1:
+        salaire_imposable: 5_000_000
+        statut_marital: marie
+  output:
+    parts_fiscales: 2
+    impot_net: 1_862_000
+
+- name: Salarié marié avec 3 revenus 10_000_000, 5_000_000 et 5_000_000
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      declarants:
+      - individu_0
+      - individu_1
+      enfants_a_charge:
+      - enfant_0
+    persons:
+      individu_0:
+        salaire_imposable: 10_000_000
+        statut_marital: marie
+      individu_1:
+        salaire_imposable: 5_000_000
+        statut_marital: marie
+      enfant_0:
+        statut_marital: celibataire
+        salaire_imposable: 5_000_000
+  output:
+    parts_fiscales: 2.5
+    salaire_imposable_apres_deduction_et_abattement: 14_600_000
+    revenus_categoriels_tspr: 14_600_000
+    revenu_brut_global: 14_600_000
+    revenu_net_global_imposable: 14_600_000
+    #impot_net: 3_042_000

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -432,7 +432,6 @@
       declarant:
         statut_marital: veuf
       enfant:
-        statut_marital: celibataire
         taux_invalidite: .80
         enfant_en_garde_alternee: true
   output:

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -435,7 +435,7 @@
         taux_invalidite: .80
         enfant_en_garde_alternee: true
   output:
-    parts_fiscales: 2.25
+    parts_fiscales: 2
 
 - name: Veuf avec 1 ascendant à charge
   period: 2024

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -28,6 +28,40 @@
   output:
     parts_fiscales: 2
 
+# - name: Couples pacsés avec un conjoint invalide
+#   period: 2024
+#   absolute_error_margin: 0
+#   input:
+#     foyer_fiscal:
+#       declarants:
+#       - declarant
+#       - conjoint
+#     persons:
+#       declarant:
+#         statut_marital: pacse
+#       conjoint:
+#         statut_marital: pacse
+#         taux_invalidite: 0.8
+#   output:
+#     parts_fiscales: 2.5
+
+- name: Couple marié avec un ancien combattant
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+      - declarant
+      - conjoint
+    persons:
+      declarant:
+        statut_marital: marie
+        ancien_combattant: true
+      conjoint:
+        statut_marital: marie
+  output:
+    parts_fiscales: 2.5
+
 
 - name: Couples mariés avec 1 enfant
   period: 2024

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -150,28 +150,28 @@
   output:
     parts_fiscales: 1.25
 
-# - name: Parent divorcé avec 2 enfants en garde alternée dont un invalide
-#   period: 2024
-#   absolute_error_margin: 0
-#   input:
-#     foyer_fiscal:
-#       declarants:
-#       - declarant
-#       enfants_a_charge:
-#       - riri
-#       - fifi
-#     persons:
-#       declarant:
-#         statut_marital: divorce
-#       riri:
-#         statut_marital: celibataire
-#         enfant_en_garde_alternee: true
-#       fifi:
-#         statut_marital: celibataire
-#         enfant_en_garde_alternee: true
-#         taux_invalidite: .80
-#   output:
-#     parts_fiscales: 1.75
+- name: Parent divorcé avec 2 enfants en garde alternée dont un invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+      - declarant
+      enfants_a_charge:
+      - riri
+      - fifi
+    persons:
+      declarant:
+        statut_marital: divorce
+      riri:
+        statut_marital: celibataire
+        enfant_en_garde_alternee: true
+      fifi:
+        statut_marital: celibataire
+        enfant_en_garde_alternee: true
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 1.75
 
 - name: Célibataire avec 1 ascendant à charge
   period: 2024
@@ -231,27 +231,27 @@
   output:
     parts_fiscales: 2.5
 
-# - name: Couple pacsé avec conjoint handicapé et 1 ascendant à charge invalide
-#   period: 2024
-#   absolute_error_margin: 0
-#   input:
-#     foyer_fiscal:
-#       declarants:
-#         - declarant
-#         - conjoint
-#       ascendants_a_charge:
-#         - ascendant
-#     persons:
-#       declarant:
-#         statut_marital: pacse
-#       conjoint:
-#         statut_marital: pacse
-#         taux_invalidite: .80
-#       ascendant:
-#         statut_marital: celibataire
-#         taux_invalidite: .80
-#   output:
-#     parts_fiscales: 3
+- name: Couple pacsé avec conjoint handicapé et 1 ascendant à charge invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+        - conjoint
+      ascendants_a_charge:
+        - ascendant
+    persons:
+      declarant:
+        statut_marital: pacse
+      conjoint:
+        statut_marital: pacse
+        taux_invalidite: .80
+      ascendant:
+        statut_marital: celibataire
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 3
 
 - name: Couple pacsé avec un étudiant hors nouvelle calédonie
   period: 2024
@@ -321,6 +321,24 @@
         statut_marital: celibataire
   output:
     parts_fiscales: 2
+
+- name: Veuf invalide avec 1 enfant à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: veuf
+        taux_invalidite: .80
+      enfant:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2.5
 
 - name: Veuf avec 1 enfant à charge invalide
   period: 2024
@@ -401,24 +419,24 @@
   output:
     parts_fiscales: 1.75
 
-# - name: Veuf avec 1 enfant handicapé en garde alternée
-#   period: 2024
-#   absolute_error_margin: 0
-#   input:
-#     foyer_fiscal:
-#       declarants:
-#         - declarant
-#       enfants_a_charge:
-#         - enfant
-#     persons:
-#       declarant:
-#         statut_marital: veuf
-#       enfant:
-#         statut_marital: celibataire
-#         taux_invalidite: .80
-#         enfant_en_garde_alternee: true
-#   output:
-#     parts_fiscales: 2.25
+- name: Veuf avec 1 enfant handicapé en garde alternée
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: veuf
+      enfant:
+        statut_marital: celibataire
+        taux_invalidite: .80
+        enfant_en_garde_alternee: true
+  output:
+    parts_fiscales: 2.25
 
 - name: Veuf avec 1 ascendant à charge
   period: 2024

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -97,3 +97,308 @@
         statut_marital: celibataire
   output:
     parts_fiscales: 3.5
+
+- name: Parent séparé avec 1 enfant en garde alternée
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+      - declarant
+      enfants_a_charge:
+      - enfant
+    persons:
+      declarant:
+        statut_marital: separe
+      enfant:
+        statut_marital: celibataire
+        enfant_en_garde_alternee: true
+  output:
+    parts_fiscales: 1.25
+
+# - name: Parent divorcé avec 2 enfants en garde alternée dont un invalide
+#   period: 2024
+#   absolute_error_margin: 0
+#   input:
+#     foyer_fiscal:
+#       declarants:
+#       - declarant
+#       enfants_a_charge:
+#       - riri
+#       - fifi
+#     persons:
+#       declarant:
+#         statut_marital: divorce
+#       riri:
+#         statut_marital: celibataire
+#         enfant_en_garde_alternee: true
+#       fifi:
+#         statut_marital: celibataire
+#         enfant_en_garde_alternee: true
+#         taux_invalidite: .80
+#   output:
+#     parts_fiscales: 1.75
+
+- name: Célibataire avec 1 ascendant à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+      - declarant
+      ascendants_a_charge:
+      - ascendant
+    persons:
+      declarant:
+        statut_marital: celibataire
+      ascendant:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 1.5
+
+- name: Couple pacsé avec 1 ascendant à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+        - conjoint
+      ascendants_a_charge:
+        - ascendant
+    persons:
+      declarant:
+        statut_marital: pacse
+      conjoint:
+        statut_marital: pacse
+      ascendant:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2.5
+
+- name: Couple pacsé avec 1 ascendant à charge invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+        - conjoint
+      ascendants_a_charge:
+        - ascendant
+    persons:
+      declarant:
+        statut_marital: pacse
+      conjoint:
+        statut_marital: pacse
+      ascendant:
+        statut_marital: celibataire
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 2.5
+
+# - name: Couple pacsé avec conjoint handicapé et 1 ascendant à charge invalide
+#   period: 2024
+#   absolute_error_margin: 0
+#   input:
+#     foyer_fiscal:
+#       declarants:
+#         - declarant
+#         - conjoint
+#       ascendants_a_charge:
+#         - ascendant
+#     persons:
+#       declarant:
+#         statut_marital: pacse
+#       conjoint:
+#         statut_marital: pacse
+#         taux_invalidite: .80
+#       ascendant:
+#         statut_marital: celibataire
+#         taux_invalidite: .80
+#   output:
+#     parts_fiscales: 3
+
+- name: Couple pacsé avec un étudiant hors nouvelle calédonie
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+        - conjoint
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: pacse
+      conjoint:
+        statut_marital: pacse
+      enfant:
+        statut_marital: celibataire
+        etudiant_hors_nc: true
+  output:
+    parts_fiscales: 3
+
+- name: Séparé avec un enfant étudiant hors nouvelle calédonie
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: separe
+      enfant:
+        statut_marital: celibataire
+        etudiant_hors_nc: true
+  output:
+    parts_fiscales: 2
+
+- name: Veuf sans personne à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+    persons:
+      declarant:
+        statut_marital: veuf
+  output:
+    parts_fiscales: 1
+
+- name: Veuf avec 1 enfant à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: veuf
+      enfant:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2
+
+- name: Veuf avec 1 enfant à charge invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: veuf
+      enfant:
+        statut_marital: celibataire
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 2.5
+
+- name: Veuf avec 2 enfants à charge dont un invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - riri
+        - fifi
+    persons:
+      declarant:
+        statut_marital: veuf
+      riri:
+        statut_marital: celibataire
+      fifi:
+        statut_marital: celibataire
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 3
+
+- name: Veuf avec 2 enfants à charge dont un invalide et un étudiant hors NC
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - riri
+        - fifi
+    persons:
+      declarant:
+        statut_marital: veuf
+      riri:
+        statut_marital: celibataire
+        etudiant_hors_nc: true
+      fifi:
+        statut_marital: celibataire
+        taux_invalidite: .80
+  output:
+    parts_fiscales: 3.5
+
+- name: Veuf avec 1 enfant en garde alternée
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      enfants_a_charge:
+        - enfant
+    persons:
+      declarant:
+        statut_marital: veuf
+      enfant:
+        statut_marital: celibataire
+        enfant_en_garde_alternee: true
+  output:
+    parts_fiscales: 1.75
+
+# - name: Veuf avec 1 enfant handicapé en garde alternée
+#   period: 2024
+#   absolute_error_margin: 0
+#   input:
+#     foyer_fiscal:
+#       declarants:
+#         - declarant
+#       enfants_a_charge:
+#         - enfant
+#     persons:
+#       declarant:
+#         statut_marital: veuf
+#       enfant:
+#         statut_marital: celibataire
+#         taux_invalidite: .80
+#         enfant_en_garde_alternee: true
+#   output:
+#     parts_fiscales: 2.25
+
+- name: Veuf avec 1 ascendant à charge
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+        - declarant
+      ascendants_a_charge:
+        - ascendant
+    persons:
+      declarant:
+        statut_marital: veuf
+      ascendant:
+        statut_marital: celibataire
+  output:
+    parts_fiscales: 2

--- a/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
+++ b/openfisca_nouvelle_caledonie/tests/prelevements_obligatoires/impot_revenu/parts_fiscales.yaml
@@ -28,22 +28,22 @@
   output:
     parts_fiscales: 2
 
-# - name: Couples pacsés avec un conjoint invalide
-#   period: 2024
-#   absolute_error_margin: 0
-#   input:
-#     foyer_fiscal:
-#       declarants:
-#       - declarant
-#       - conjoint
-#     persons:
-#       declarant:
-#         statut_marital: pacse
-#       conjoint:
-#         statut_marital: pacse
-#         taux_invalidite: 0.8
-#   output:
-#     parts_fiscales: 2.5
+- name: Couples pacsés avec un conjoint invalide
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    foyer_fiscal:
+      declarants:
+      - declarant
+      - conjoint
+    persons:
+      declarant:
+        statut_marital: pacse
+      conjoint:
+        statut_marital: pacse
+        taux_invalidite: 0.8
+  output:
+    parts_fiscales: 2.5
 
 - name: Couple marié avec un ancien combattant
   period: 2024

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -122,7 +122,6 @@ class parts_fiscales(Variable):
         parts_de_base += parts_additionnelles
         # `enfant` represents whether each member of the fiscal household has the role ENFANT_A_CHARGE.
         enfant = foyer_fiscal.members.has_role(FoyerFiscal.ENFANT_A_CHARGE)
-        enfant = int(enfant)  # Convert to integer for clarity in subsequent calculations.
         enfant_en_garde_alternee_i = enfant * foyer_fiscal.members(
             "enfant_en_garde_alternee", period
         )

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -120,7 +120,9 @@ class parts_fiscales(Variable):
             )  # TODO: parameters
         )
         parts_de_base += parts_additionnelles
+        # `enfant` represents whether each member of the fiscal household has the role ENFANT_A_CHARGE.
         enfant = foyer_fiscal.members.has_role(FoyerFiscal.ENFANT_A_CHARGE)
+        enfant = int(enfant)  # Convert to integer for clarity in subsequent calculations.
         enfant_en_garde_alternee_i = enfant * foyer_fiscal.members(
             "enfant_en_garde_alternee", period
         )

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -109,7 +109,7 @@ class parts_fiscales(Variable):
         invalidite_i = foyer_fiscal.members("taux_invalidite", period) > 0.5
 
         enfants_parts_entiere_i = etudiant_hors_nc_i + handicape_cejh_i + invalidite_i
-        parts_enfants = foyer_fiscal.sum(
+        parts_enfants = foyer_fiscal.sum( #TODO: Erreur dans le calcul des parts garde alternée
             (
                 parts_fiscales.enfant_part_entiere
                 * (enfants_parts_entiere_i)
@@ -126,7 +126,6 @@ class parts_fiscales(Variable):
             ),
             role=FoyerFiscal.ENFANT_A_CHARGE,
         )
-        # TODO: mettre ces parts dans les paramètres
         parts_ascendants = (
             foyer_fiscal.nb_persons(role=FoyerFiscal.ASCENDANT_A_CHARGE)
             * parts_fiscales.ascendant_a_charge

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -125,14 +125,16 @@ class parts_fiscales(Variable):
         #     foyer_fiscal.members("enfant_en_garde_alternee", period),
         #     role=FoyerFiscal.ENFANT_A_CHARGE,
         # )
-        enfant_en_garde_alternee_i = foyer_fiscal.members(
+
+        enfant = foyer_fiscal.members.has_role(FoyerFiscal.ENFANT_A_CHARGE)
+        enfant_en_garde_alternee_i = enfant * foyer_fiscal.members(
             "enfant_en_garde_alternee", period
         )
-        etudiant_hors_nc_i = foyer_fiscal.members("etudiant_hors_nc", period)
-        handicape_cejh_i = foyer_fiscal.members("handicape_cejh", period)
-        invalidite_i = foyer_fiscal.members("taux_invalidite", period) > 0.5
+        etudiant_hors_nc_i = enfant * foyer_fiscal.members("etudiant_hors_nc", period)
+        handicape_cejh_i = enfant * foyer_fiscal.members("handicape_cejh", period)
+        invalidite_i = enfant * (foyer_fiscal.members("taux_invalidite", period) > 0.5)
 
-        enfants_parts_entiere_i = etudiant_hors_nc_i + handicape_cejh_i + invalidite_i
+        enfants_parts_entiere_i = (etudiant_hors_nc_i + handicape_cejh_i + invalidite_i)
         parts_enfants = (
             foyer_fiscal.sum(  # TODO: Erreur dans le calcul des parts garde alternée
                 (

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -63,6 +63,12 @@ class taux_invalidite(Variable):
     label = "Taux d'invalidité"
     definition_period = YEAR
 
+class ancien_combattant(Variable):
+    value_type = bool
+    default_value = False
+    entity = Individu
+    label = "Ancien combattant"
+    definition_period = YEAR
 
 class parts_fiscales(Variable):
     value_type = float
@@ -99,6 +105,16 @@ class parts_fiscales(Variable):
                 parts_fiscales.veuf_avec_pac,
             ],
         )
+        parts_additionnelles = (
+            parts_fiscales.ancien_combattant * (
+                foyer_fiscal.declarant_principal("ancien_combattant", period)
+                )
+            + parts_fiscales.handicape * (
+                foyer_fiscal.declarant_principal("taux_invalidite", period) > 0.5
+                + foyer_fiscal.conjoint("taux_invalidite", period) > 0.5
+            )
+        )
+        parts_de_base += parts_additionnelles
 
         enfant_en_garde_alternee_i = foyer_fiscal.sum(
             foyer_fiscal.members("enfant_en_garde_alternee", period),

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -120,12 +120,6 @@ class parts_fiscales(Variable):
             )  # TODO: parameters
         )
         parts_de_base += parts_additionnelles
-
-        # enfant_en_garde_alternee_i = foyer_fiscal.sum(
-        #     foyer_fiscal.members("enfant_en_garde_alternee", period),
-        #     role=FoyerFiscal.ENFANT_A_CHARGE,
-        # )
-
         enfant = foyer_fiscal.members.has_role(FoyerFiscal.ENFANT_A_CHARGE)
         enfant_en_garde_alternee_i = enfant * foyer_fiscal.members(
             "enfant_en_garde_alternee", period

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -110,8 +110,8 @@ class parts_fiscales(Variable):
                 foyer_fiscal.declarant_principal("ancien_combattant", period)
                 )
             + parts_fiscales.handicape * (
-                1 * (foyer_fiscal.declarant_principal("taux_invalidite", period) > 0.5)  # TODO parameters
-                + 1 * (foyer_fiscal.conjoint("taux_invalidite", period) > 0.5)  # TODO parameters
+                1 * (foyer_fiscal.declarant_principal("taux_invalidite", period) > 0.5)  # TODO: parameters
+                + 1 * (foyer_fiscal.conjoint("taux_invalidite", period) > 0.5)  # TODO: parameters
                 )
             )
         parts_de_base += parts_additionnelles

--- a/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
+++ b/openfisca_nouvelle_caledonie/variables/prelevements_obligatoires/impot_revenu/situation_de_famille.py
@@ -110,10 +110,10 @@ class parts_fiscales(Variable):
                 foyer_fiscal.declarant_principal("ancien_combattant", period)
                 )
             + parts_fiscales.handicape * (
-                foyer_fiscal.declarant_principal("taux_invalidite", period) > 0.5
-                + foyer_fiscal.conjoint("taux_invalidite", period) > 0.5
+                1 * (foyer_fiscal.declarant_principal("taux_invalidite", period) > 0.5)  # TODO parameters
+                + 1 * (foyer_fiscal.conjoint("taux_invalidite", period) > 0.5)  # TODO parameters
+                )
             )
-        )
         parts_de_base += parts_additionnelles
 
         enfant_en_garde_alternee_i = foyer_fiscal.sum(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61" ]
 [project]
 name = "openfisca-nouvelle_caledonie"
 
-version = "13.0.2"
+version = "13.1.0"
 description = "OpenFisca Rules as Code model for Nouvelle Calédonie."
 readme = "README.md"
 keywords = [ "benefit", "microsimulation", "rac", "rules-as-code", "tax" ]

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-nouvelle-caledonie"
-version = "12.0.0"
+version = "13.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-nouvelle-caledonie"
-version = "13.0.2"
+version = "13.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : toutes. 
* Zones impactées : `prelevements_obligatoires/impot_revenu/situation_de_famille.py`.
* Détails :
  -  Ajout de la nouvelle variable ancien_combattant avec sa configuration de paramètres associée.
  -  Modification de la formule de calcul des éléments fiscaux afin de tenir compte de conditions telles que l'invalidité et le statut d'ancien combattant.
  - Ajout du plafonnement du quotient familial intervenu en 2016.
  - Extension de la couverture des tests avec de nombreux scénarios YAML et correction de fautes de frappe mineures.

